### PR TITLE
tests: pin max_clients=1 in T-SR11/T-SR11b to fix reorder_0 flakiness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, dev]
   pull_request:
-    branches: [master]
+    branches: [master, dev]
   workflow_dispatch:
 
 env:

--- a/features/memory_receive.feature
+++ b/features/memory_receive.feature
@@ -152,22 +152,15 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     Then receiver memory did not grow by more than 10 MB during thread pause
 
   Scenario: T-SR11 - to_clients/client_sendq grows unbounded when client worker is slow
-    # Issues 4+5: client_queue_size=0 makes client_sendq unbounded (dispatch.rs:108).
-    # When reorder_0 is starved it cannot drain client_recvq; blocks accumulate
-    # without limit and lidi-receive RSS grows uncontrollably.
-    # TDD test: demonstrates the bug by verifying memory DOES grow >5 MB.
-    # Fix: set client_queue_size > 0 (see T-SR11b).
-    Given lidi is started with max throughput of 400mbit
+    Given max_clients is configured to 1
+    And lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr11.bin of size 100MB
     And lidi-receive reorder_0 thread is paused until memory grows by 10 MB or 3 seconds
     Then receiver memory grew by more than 10 MB during thread pause
 
   Scenario: T-SR11b - client_queue_size=4 bounds memory when client worker is slow
-    # Fix verified: client_queue_size=4 caps each client_sendq at 4 decoded blocks (≈ 880 KB).
-    # When reorder_0 is starved, try_send fails once the queue is full; blocks are dropped.
-    # The upstream pipeline (reblock→dispatch) runs normally; no cascade backpressure.
-    # Only the per-client sendq grows, bounded at 4 × block_size ≈ 880 KB.
     Given lidi is started with max throughput of 400mbit
+    And max_clients is configured to 1
     And reblock_queue_size is configured to 128
     And dispatch_queue_size is configured to 128
     And clients_queue_size is configured to 128

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -237,11 +237,6 @@ def step_set_encoding(context, encoding):
 def step_set_encoding(context, repair):
     context.repair = repair
 
-@given('lidi is started with max clients set to {max_clients:d}')
-def step_set_max_clients(context, max_clients):
-    """Set the maximum number of concurrent clients."""
-    context.max_clients = max_clients
-
 @when('lidi-file-send file {name} of size {size} with hash')
 def step_send_file_with_hash(context, name, size):
     """Send a file with hash verification enabled."""
@@ -1266,6 +1261,19 @@ def step_configure_abort_timeout(context, duration_s):
 def step_disable_abort_timeout(context):
     """Disable abort_timeout (set to 0 or None)."""
     context.abort_timeout = 0
+
+
+@given('max_clients is configured to {n:d}')
+def step_configure_max_clients(context, n):
+    """Configure the number of parallel client worker slots.
+
+    Each slot spawns a reorder_<slot_index> thread once it picks up a
+    connection from the shared for_clients channel; with max_clients > 1,
+    which slot handles a given client is a race with no deterministic
+    winner. Tests that target a specific reorder_<N> thread name must pin
+    max_clients=1 to make that assignment deterministic.
+    """
+    context.max_clients = n
 
 
 @given('client_queue_size is configured to {size}')


### PR DESCRIPTION
reorder_<N> threads are named after the client-worker slot index, not the client itself. With the default max_clients=2, two worker threads race on the shared for_clients channel to pick up the single test client, so reorder_0 was sometimes never spawned — causing an intermittent "thread not found" failure under CI scheduling. Pinning max_clients=1 makes the slot assignment deterministic.